### PR TITLE
Relax upper constraint on prompt_toolkit

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - jupyter_client
     - ipython
     - ipykernel
-    - prompt_toolkit >=2.0.0,<3.10
+    - prompt_toolkit >=2.0.0,<3.1.0
     - pygments
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 308ce876354924fb6c540b41d5d6d08acfc946984bf0c97777c1ddcb42e0b2f5
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - jupyter_client
     - ipython
     - ipykernel
-    - prompt_toolkit >=2.0.0,<2.1.0
+    - prompt_toolkit >=2.0.0
     - pygments
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - jupyter_client
     - ipython
     - ipykernel
-    - prompt_toolkit >=2.0.0
+    - prompt_toolkit >=2.0.0,<3.10
     - pygments
 
 test:


### PR DESCRIPTION
See my [previous comment](https://github.com/conda-forge/jupyter_console-feedstock/commit/3beb5debe23d34b5c5ace5ea0c3ed2b6f4e957b9#r36612098) regarding [`prompt_toolkit=3.0.2`](https://github.com/conda-forge/prompt_toolkit-feedstock/blob/5af632e15e16b9aa6f79e164728e13b5f5dacb73/recipe/meta.yaml#L1) now being available.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
